### PR TITLE
fix `TypeError: can’t cast Array`

### DIFF
--- a/lib/ranema/actions/add_deprecation_warning_postgresql.rb
+++ b/lib/ranema/actions/add_deprecation_warning_postgresql.rb
@@ -20,11 +20,9 @@ module Ranema
       end
 
       def performed?
-        exec_query(
-          "SELECT exists(SELECT * FROM pg_proc WHERE proname = $1)",
-          "SQL",
-          [[nil, trigger_name]]
-        ).to_a.first["exists"]
+        exec_query("SELECT exists(SELECT * FROM pg_proc WHERE proname = $1)", "SQL", [trigger_name])
+          .to_a
+          .first["exists"]
       end
 
       def trigger

--- a/lib/ranema/actions/add_sanity_check_constraint.rb
+++ b/lib/ranema/actions/add_sanity_check_constraint.rb
@@ -23,11 +23,7 @@ module Ranema
       end
 
       def performed?
-        exec_query(
-          query,
-          "SQL",
-          [[nil, check_name]]
-        ).to_a.first.present?
+        exec_query(query,"SQL", [check_name]).to_a.first.present?
       end
 
       def query

--- a/lib/ranema/actions/copy_checks.rb
+++ b/lib/ranema/actions/copy_checks.rb
@@ -43,11 +43,7 @@ module Ranema
 
       # @return [Array<Hash>]
       def checks
-        @checks ||= exec_query(
-          query,
-          "SQL",
-          [[nil, table_name], [nil, sync_check_name]]
-        ).to_a
+        @checks ||= exec_query(query, "SQL", [table_name, sync_check_name]).to_a
       end
 
       def query

--- a/lib/ranema/actions/copy_default.rb
+++ b/lib/ranema/actions/copy_default.rb
@@ -36,7 +36,7 @@ module Ranema
       end
 
       def new_column_default
-        exec_query(<<~SQL, "SQL", [[nil, table_name], [nil, new_column_name]]).rows.first.first
+        exec_query(<<~SQL, "SQL", [table_name, new_column_name]).rows.first.first
           SELECT "columns".column_default
           FROM "information_schema"."columns" columns
           WHERE columns."table_name" = $1

--- a/lib/ranema/actions/copy_null_constraint.rb
+++ b/lib/ranema/actions/copy_null_constraint.rb
@@ -22,11 +22,7 @@ module Ranema
       end
 
       def new_column_null
-        exec_query(
-          query,
-          "SQL",
-          [[nil, table_name], [nil, new_column_name]]
-        ).to_a.first["is_nullable"] == "YES"
+        exec_query(query, "SQL", [table_name, new_column_name]).to_a.first["is_nullable"] == "YES"
       end
 
       def query

--- a/lib/ranema/actions/copy_triggers.rb
+++ b/lib/ranema/actions/copy_triggers.rb
@@ -35,12 +35,14 @@ module Ranema
 
       # @return [Array<Hash>]
       def triggers
-        @triggers ||= exec_query(
-          query,
-          "SQL",
-          [[nil, table_name],
-           [nil, SyncNewColumn.new(table_name, old_column_name, new_column_name).trigger_name]]
-        ).to_a
+        @triggers ||= exec_query(query, "SQL", binds).to_a
+      end
+
+      def binds
+        [
+          table_name,
+          SyncNewColumn.new(table_name, old_column_name, new_column_name).trigger_name
+        ]
       end
 
       def query

--- a/lib/ranema/actions/prepend_missing_table_names.rb
+++ b/lib/ranema/actions/prepend_missing_table_names.rb
@@ -43,7 +43,7 @@ module Ranema
       end
 
       def tables
-        ActiveRecord::Base.connection.exec_query(<<~SQL, "SQL", [[nil, new_column_name]]).to_a
+        ActiveRecord::Base.connection.exec_query(<<~SQL, "SQL", [new_column_name]).to_a
           SELECT
             "information_schema"."table_name"
           FROM

--- a/lib/ranema/actions/sync_triggers_with_raise.rb
+++ b/lib/ranema/actions/sync_triggers_with_raise.rb
@@ -33,11 +33,9 @@ module Ranema
       end
 
       def performed?
-        exec_query(
-          "SELECT exists(SELECT * FROM pg_proc WHERE proname IN($1))",
-          "SQL",
-          [[nil, trigger_names.join(", ")]]
-        ).to_a.first["exists"]
+        exec_query("SELECT exists(SELECT * FROM pg_proc WHERE proname IN($1))", "SQL", [trigger_names.join(", ")])
+          .to_a
+          .first["exists"]
       end
 
       def update_old_column_trigger_name

--- a/lib/ranema/helpers/migrations.rb
+++ b/lib/ranema/helpers/migrations.rb
@@ -117,7 +117,7 @@ module Ranema
       end
 
       def trigger_exists?(table_name, name)
-        exec_query(<<~SQL.squish, "SQL", [[nil, table_name], [nil, name]]).to_a.first["exists"]
+        query = <<~SQL.squish
           SELECT exists(
             SELECT *
             FROM pg_trigger
@@ -126,6 +126,7 @@ module Ranema
               AND pg_trigger.tgname = $2
           )
         SQL
+        exec_query(query, "SQL", [name, table_name]).to_a.first["exists"]
       end
 
       def exec_query(*args)


### PR DESCRIPTION
https://bibwild.wordpress.com/2022/03/28/rails7-connection-select_all-is-stricter-about-its-arguments-in-backwards-incompat-way-typeerror-cant-cast-array/